### PR TITLE
adding support for getprop and listprop

### DIFF
--- a/libc/include/sys/_system_properties.h
+++ b/libc/include/sys/_system_properties.h
@@ -74,6 +74,8 @@ struct prop_msg
 };
 
 #define PROP_MSG_SETPROP 1
+#define PROP_MSG_GETPROP 2
+#define PROP_MSG_LISTPROP 3
     
 /*
 ** Rules:


### PR DESCRIPTION
this fixes the issue when enabling droid-hal-init breaks pulseaudio

should be merged together with: 
https://github.com/mer-hybris/android_system_core/pull/2
