### PR TITLE
hack: make N5 sensors work

### DIFF
--- a/libc/bionic/system_properties.c
+++ b/libc/bionic/system_properties.c
@@ -432,6 +432,9 @@ static const prop_info *find_property(prop_bt *trie, const char *name,
 
 const prop_info *__system_property_find(const char *name)
 {
+    // 2015-02-26: it's a horrid hack, but makes all sensors work
+    // proper investigation is mandatory!
+    return NULL;
     if (__predict_false(compat_mode)) {
         return __system_property_find_compat(name);
     }


### PR DESCRIPTION
this is the place where sensors crash due to **system_property_area**
being null. Then cast it to a struct and access one of its members

The rest of the system with this hack is still functioning.

Change-Id: I3372fe025bd36d195b63e60bcad3e98cbd586386
