### PR TITLE
fix Nexus 5 (and others) sensors for good

### DIFF
--- a/libc/bionic/system_properties.c
+++ b/libc/bionic/system_properties.c
@@ -468,6 +468,12 @@ int __system_property_get(const char *name, char *value)
 {
     const prop_info *pi = __system_property_find(name);
 
+    /* In case we're called from Ubuntu */
+    if (__system_property_area__ == NULL) {
+        value[0] = 0;
+        return 0;
+    }
+
     if(pi != 0) {
         return __system_property_read(pi, 0, value);
     } else {


### PR DESCRIPTION
Been tested in local build and it works!

Original commit:

```
system_properties.c: returning empty value in case it's called from Ubuntu

As it can't access the memory map, and /dev/__properties__ is not
available unless you're inside the Android container.

Change-Id: I1b9e161011d913cc10d6734c8ae7b9991d7fa4cb
Signed-off-by: Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
```

Conflicts:
    libc/bionic/system_properties.c
Backported fine.

[mer-hybris] Fixes NEMO#790

Nexus 5 sensors now work straight away, and build flow doesn't need a two-pass compilation hack anymore.

Thanks to @stskeeps for bringing this out during AOSP5 work.

Signed-off-by: Simonas Leleiva simonas.leleiva@jollamobile.com
