### PR TITLE
(hybris) Don't report fsetxattr_failed error in map_prop_area_rw

### DIFF
--- a/libc/bionic/system_properties.cpp
+++ b/libc/bionic/system_properties.cpp
@@ -252,7 +252,10 @@ static prop_area* map_prop_area_rw(const char* filename, const char* context,
              * property separation.
              */
             if (fsetxattr_failed) {
-                *fsetxattr_failed = true;
+                /* It's going to fail without SELinux. Set fsetxattr_failed to false anyway
+                 * to avoid "init: Failed to initialize property area" error
+                 */
+                *fsetxattr_failed = false;
             }
         }
     }


### PR DESCRIPTION
This is needed to avoid "init: Failed to initialize property area" error without SELinux enabled.