### PR TITLE
[WIP] hybris-15.1: Re-enable __get_tls define

### DIFF
--- a/libc/bionic/locale.cpp
+++ b/libc/bionic/locale.cpp
@@ -37,11 +37,11 @@
 
 #include "private/bionic_macros.h"
 
-#if defined(__BIONIC_BUILD_FOR_ANDROID_SUPPORT)
+//#if defined(__BIONIC_BUILD_FOR_ANDROID_SUPPORT)
 #define USE_TLS_SLOT 0
-#else
-#define USE_TLS_SLOT 1
-#endif
+//#else
+//#define USE_TLS_SLOT 1
+//#endif
 
 #if USE_TLS_SLOT
 #include "bionic/pthread_internal.h"

--- a/libc/bionic/ndk_cruft.cpp
+++ b/libc/bionic/ndk_cruft.cpp
@@ -49,6 +49,18 @@
 
 extern "C" {
 
+void** __get_tls_hooks(void) {
+#include "private/__get_tls_internal.h"
+  return __get_tls_internal();
+}
+
+// TODO: does anything still need this?
+// with hybris we need it, so thanks for keeping it.
+void** __get_tls() {
+#include "private/__get_tls_internal.h"
+    return __get_tls_internal();
+}
+
 // LP64 doesn't need to support any legacy cruft.
 #if !defined(__LP64__)
 
@@ -68,12 +80,6 @@ pid_t __wait4(pid_t pid, int* status, int options, struct rusage* rusage) {
 // TODO: does anything still need this?
 int __open() {
   abort();
-}
-
-// TODO: does anything still need this?
-void** __get_tls() {
-#include "private/__get_tls.h"
-  return __get_tls();
 }
 
 // This non-standard function was in our <string.h> for some reason.

--- a/libc/include/sys/_system_properties.h
+++ b/libc/include/sys/_system_properties.h
@@ -44,6 +44,8 @@ __BEGIN_DECLS
 #define PROP_FILENAME "/dev/__properties__"
 
 #define PROP_MSG_SETPROP 1
+#define PROP_MSG_GETPROP 2
+#define PROP_MSG_LISTPROP 3
 #define PROP_MSG_SETPROP2 0x00020001
 
 #define PROP_SUCCESS 0

--- a/libc/libc.arm.map
+++ b/libc/libc.arm.map
@@ -1416,6 +1416,7 @@ LIBC_PRIVATE {
     __gedf2; # arm
     __get_thread; # arm x86 mips
     __get_tls; # arm x86 mips
+    __get_tls_hooks; # hybris
     __getdents64; # arm x86 mips
     __gnu_ldivmod_helper; # arm
     __gnu_uldivmod_helper; # arm

--- a/libc/libc.arm64.map
+++ b/libc/libc.arm64.map
@@ -1240,6 +1240,7 @@ LIBC_O {
 
 LIBC_PRIVATE {
   global:
+    __get_tls_hooks; # hybris
     android_getaddrinfofornet;
     android_getaddrinfofornetcontext;
     android_gethostbyaddrfornet;

--- a/libc/libc.x86.map
+++ b/libc/libc.x86.map
@@ -1308,6 +1308,7 @@ LIBC_PRIVATE {
     __futex_wake; # arm x86 mips
     __get_thread; # arm x86 mips
     __get_tls; # arm x86 mips
+    __get_tls_hooks; # hybris
     __getdents64; # arm x86 mips
     __open; # arm x86 mips
     __page_shift; # arm x86 mips

--- a/libc/private/__get_tls.h
+++ b/libc/private/__get_tls.h
@@ -40,6 +40,6 @@ void **__get_tls_hooks(void);
 
 #include "__get_tls_internal.h"
 
-//#define __get_tls __get_tls_hooks
+#define __get_tls __get_tls_hooks
 
 #endif /* __BIONIC_PRIVATE_GET_TLS_H_ */

--- a/libc/private/__get_tls_internal.h
+++ b/libc/private/__get_tls_internal.h
@@ -26,20 +26,29 @@
  * SUCH DAMAGE.
  */
 
-#ifndef __BIONIC_PRIVATE_GET_TLS_H_
-#define __BIONIC_PRIVATE_GET_TLS_H_
+#ifndef __BIONIC_PRIVATE_GET_TLS_INTERNAL_H_
+#define __BIONIC_PRIVATE_GET_TLS_INTERNAL_H_
 
-#ifdef __cplusplus
-extern "C" {
+#if defined(__aarch64__)
+# define __get_tls_internal() ({ void** __val; __asm__("mrs %0, tpidr_el0" : "=r"(__val)); __val; })
+#elif defined(__arm__)
+# define __get_tls_internal() ({ void** __val; __asm__("mrc p15, 0, %0, c13, c0, 3" : "=r"(__val)); __val; })
+#elif defined(__mips__)
+# define __get_tls_internal() \
+    /* On mips32r1, this goes via a kernel illegal instruction trap that's optimized for v1. */ \
+    ({ register void** __val asm("v1"); \
+       __asm__(".set    push\n" \
+               ".set    mips32r2\n" \
+               "rdhwr   %0,$29\n" \
+               ".set    pop\n" : "=r"(__val)); \
+       __val; })
+#elif defined(__i386__)
+# define __get_tls_internal() ({ void** __val; __asm__("movl %%gs:0, %0" : "=r"(__val)); __val; })
+#elif defined(__x86_64__)
+# define __get_tls_internal() ({ void** __val; __asm__("mov %%fs:0, %0" : "=r"(__val)); __val; })
+#else
+#error unsupported architecture
 #endif
-void **__get_tls(void);
-void **__get_tls_hooks(void);
-#ifdef __cplusplus
-}
-#endif
 
-#include "__get_tls_internal.h"
+#endif /* __BIONIC_PRIVATE_GET_TLS_INTERNAL_H_ */
 
-//#define __get_tls __get_tls_hooks
-
-#endif /* __BIONIC_PRIVATE_GET_TLS_H_ */

--- a/libc/private/bionic_tls.h
+++ b/libc/private/bionic_tls.h
@@ -56,12 +56,12 @@ __BEGIN_DECLS
 enum {
   TLS_SLOT_SELF = 0, // The kernel requires this specific slot for x86.
   TLS_SLOT_THREAD_ID,
-  TLS_SLOT_ERRNO,
+  TLS_SLOT_ERRNO = 5,
 
   // These two aren't used by bionic itself, but allow the graphics code to
   // access TLS directly rather than using the pthread API.
-  TLS_SLOT_OPENGL_API = 3,
-  TLS_SLOT_OPENGL = 4,
+  TLS_SLOT_OPENGL_API = 6,
+  TLS_SLOT_OPENGL = 7,
 
   // This slot is only used to pass information from the dynamic linker to
   // libc.so when the C library is loaded in to memory. The C runtime init
@@ -69,7 +69,7 @@ enum {
   // we reuse an existing location that isn't needed during libc startup.
   TLS_SLOT_BIONIC_PREINIT = TLS_SLOT_OPENGL_API,
 
-  TLS_SLOT_STACK_GUARD = 5, // GCC requires this specific slot for x86.
+  TLS_SLOT_STACK_GUARD = 8, // GCC requires this specific slot for x86.
   TLS_SLOT_DLERROR,
 
   // Fast storage for Thread::Current() in ART.

--- a/libc/private/bionic_tls.h
+++ b/libc/private/bionic_tls.h
@@ -56,21 +56,22 @@ __BEGIN_DECLS
 enum {
   TLS_SLOT_SELF = 0, // The kernel requires this specific slot for x86.
   TLS_SLOT_THREAD_ID,
-  TLS_SLOT_ERRNO = 5,
+
+  TLS_SLOT_STACK_GUARD = 5, // GCC requires this specific slot for x86.
+  
+  TLS_SLOT_ERRNO,
 
   // These two aren't used by bionic itself, but allow the graphics code to
   // access TLS directly rather than using the pthread API.
-  TLS_SLOT_OPENGL_API = 6,
-  TLS_SLOT_OPENGL = 7,
+  TLS_SLOT_OPENGL_API,
+  TLS_SLOT_OPENGL,
+  TLS_SLOT_DLERROR,
 
   // This slot is only used to pass information from the dynamic linker to
   // libc.so when the C library is loaded in to memory. The C runtime init
   // function will then clear it. Since its use is extremely temporary,
   // we reuse an existing location that isn't needed during libc startup.
   TLS_SLOT_BIONIC_PREINIT = TLS_SLOT_OPENGL_API,
-
-  TLS_SLOT_STACK_GUARD = 8, // GCC requires this specific slot for x86.
-  TLS_SLOT_DLERROR,
 
   // Fast storage for Thread::Current() in ART.
   TLS_SLOT_ART_THREAD_SELF,


### PR DESCRIPTION
This is needed to avoid build errors

(__get_tls was commented out in 910f43cd86)

Signed-off-by: ix5 <ix5@users.noreply.github.com>