### PR TITLE
[WIP] linker: Remove lineage buildvars from Android.bp

### DIFF
--- a/linker/Android.bp
+++ b/linker/Android.bp
@@ -105,14 +105,6 @@ cc_binary {
         debuggable: {
             cppflags: ["-DUSE_LD_CONFIG_FILE"],
         },
-        lineage: {
-            needs_text_relocations: {
-                cppflags: ["-DTARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS"],
-            },
-            target_shim_libs: {
-                cppflags: ["-DLD_SHIM_LIBS=\"%s\""],
-            },
-        },
     },
 
     cppflags: ["-Wold-style-cast"],


### PR DESCRIPTION
This prevents build errors in AOSP environments where `lineage{}` product targets are not recognized.